### PR TITLE
fix JUJU_AVAILABILITY_ZONE usage

### DIFF
--- a/hooks/ceph_hooks.py
+++ b/hooks/ceph_hooks.py
@@ -186,12 +186,12 @@ def install():
 
 def az_info():
     az_info = ""
+    config_az = config("availability_zone")
     juju_az_info = os.environ.get('JUJU_AVAILABILITY_ZONE')
     if juju_az_info:
-        az_info = "{} juju_availability_zone={}".format(az_info, juju_az_info)
-    config_az = config("availability_zone")
+        az_info = "{} rack={}".format(az_info, juju_az_info)
     if config_az:
-        az_info = "{} config_availability_zone={}".format(az_info, config_az)
+        az_info = "{} row={}".format(az_info, config_az)
     if az_info != "":
         log("AZ Info: " + az_info)
         return az_info


### PR DESCRIPTION
Backport fix:
juju_availability_zone is not a valid configuration setting, let's use
'rack' instead.

Change-Id: I6763377f253e6feb92d7c4c31eefc600cce3a8b8
Closes-Bug: #1684330