### PR TITLE
Backport: Fast exit if device_node for block device is None

### DIFF
--- a/lib/ceph/utils.py
+++ b/lib/ceph/utils.py
@@ -176,6 +176,9 @@ def unmounted_disks():
     context = pyudev.Context()
     for device in context.list_devices(DEVTYPE='disk'):
         if device['SUBSYSTEM'] == 'block':
+            if device.device_node is None:
+                continue
+
             matched = False
             for block_type in [u'dm', u'loop', u'ram', u'nbd']:
                 if block_type in device.device_node:


### PR DESCRIPTION
Backport change-id I6e61d13617f2e7ec500a0b010516a07af2a1e917 (commit
425465d4738cd4b50b457d54dfa49021e7e3d115) from
https://review.opendev.org/c/openstack/charms.ceph/+/712886